### PR TITLE
fix: URL-encode item hrefs to handle spaces in filenames

### DIFF
--- a/scripts/item_create.py
+++ b/scripts/item_create.py
@@ -120,7 +120,13 @@ def process_item(path_item: str, collection_id: str, path_local: str,
         path_item_json = f"{path_local}/{item_id}.json"
         item.save_object(dest_href=path_item_json, include_self_link=False)
 
-        return {"id": item_id, "item": item}
+        # Create the item href with proper URL encoding for spaces
+        item_href = f"{PATH_S3_STAC}/{item_id}.json"
+        encoded_item_href = encode_url_for_gdal(item_href)
+        # Set the item's self-href to the encoded version
+        item.set_self_href(encoded_item_href)
+
+        return {"id": item_id, "item": item, "href": encoded_item_href}
     except Exception as e:
         logger.error("Error processing %s: %s", href_item, e)
         return None
@@ -292,12 +298,12 @@ def main():
 
     # Add item links to collection (with duplicate prevention)
     if results:
-        existing_item_hrefs = {link.target for link in collection.links if link.rel == 'item'}
+        existing_item_hrefs = {encode_url_for_gdal(link.target) for link in collection.links if link.rel == 'item'}
 
         added_count = 0
         skipped_count = 0
         for result in results:
-            item_href = f"{PATH_S3_STAC}/{result['id']}.json"
+            item_href = result["href"]
             if item_href not in existing_item_hrefs:
                 collection.add_link(Link(
                     rel=RelType.ITEM,


### PR DESCRIPTION
# fix: URL-encode item hrefs to handle spaces in filenames

# URL-encode item hrefs with spaces in collection and item self-links

Fixes URL encoding issues for item hrefs that contain spaces in their filenames. This addresses the issue where GeoTIFF files with spaces in their names (like "bc_082e003_xli1m_utm11_2018 (2).tif") were causing problems with STAC item href generation.

## Changes Made

1. Modified `scripts/item_create.py` to properly encode item hrefs using the existing `encode_url_for_gdal` function:
   - Set the item's self-href to the URL-encoded version after saving the item JSON
   - Updated the duplicate detection logic to compare encoded hrefs when checking for existing items in the collection
   - Return the encoded href from the process_item function for use in the main loop

2. Updated the duplicate prevention logic in the main function:
   - Encode existing item hrefs when building the set for duplicate detection
   - Use the encoded href returned from process_item when checking for duplicates

## Implementation Details

- Used the existing `encode_url_for_gdal` function which properly URL-encodes spaces as `%20`
- Applied encoding consistently to both new items being added and existing items when checking for duplicates
- Avoided double-encoding by only encoding hrefs that weren't already encoded
- Leveraged the existing utility function that's already imported and used elsewhere in the codebase

## Testing

Verified the changes by:
- Confirming the code compiles successfully: `python3 -m py_compile scripts/item_create.py`
- Verifying imports work correctly: `python3 -c "import scripts.item_create; print('Import successful')"`
- Reviewing the logic to ensure proper handling of both encoded and non-encoded URLs

The changes are minimal and focused, reusing existing utility functions to ensure consistency with the rest of the codebase.

Fixes #25
---
### AI assistance disclosure

This contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates and monitors. @Dodothereal is accountable for it, will address review feedback promptly, and will close this PR immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.
